### PR TITLE
GNOME 47

### DIFF
--- a/io.gitlab.news_flash.NewsFlash.json
+++ b/io.gitlab.news_flash.NewsFlash.json
@@ -1,14 +1,14 @@
 {
     "app-id" : "io.gitlab.news_flash.NewsFlash",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "46",
+    "runtime-version" : "47",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
     ],
     "add-extensions": {
         "org.freedesktop.Platform.ffmpeg-full": {
-            "version": "23.08",
+            "version": "24.08",
             "directory": "lib/ffmpeg",
             "add-ld-path": ".",
             "no-autodownload": false,


### PR DESCRIPTION
Update runtime to 47 which is based on Freedesktop 24.08 with corresponding ffmpeg-full