### PR TITLE
chore: bump runtime to gnome 48

### DIFF
--- a/io.gitlab.news_flash.NewsFlash.json
+++ b/io.gitlab.news_flash.NewsFlash.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.gitlab.news_flash.NewsFlash",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
tested with `flatpak run --runtime-version=48 io.gitlab.news_flash.NewsFlash`