### PR TITLE
Update Runtime Version to 48, incl. update to blueprint v0.16.0

### DIFF
--- a/io.gitlab.news_flash.NewsFlash.json
+++ b/io.gitlab.news_flash.NewsFlash.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.gitlab.news_flash.NewsFlash",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -83,7 +83,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "tag": "v0.14.0"
+                    "tag": "v0.16.0"
                 }
             ]
         },


### PR DESCRIPTION
New runtime brings altered dark theme and corner radii of Libadwaita 1.7, blueprint v0.16.0 is required to build successfully.